### PR TITLE
Added support for official repos

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ minix.newEndpoint("/image/",function(req,res) {
   cache.get(url[2],url[3],function(e,props) {
     if(e) return serverError(req,res,503,e)
     res.setHeader("Content-Type","image/svg+xml")
-    props.name = url[2]+"/"+url[3]
+    props.name = url[2]==='_'?url[3]:url[2]+"/"+url[3];
     console.log(props)
     res.end(badge(props))
   })

--- a/scrapper/index.js
+++ b/scrapper/index.js
@@ -1,7 +1,8 @@
 var scrap = require('scrap');
 
 var m = module.exports = function(namespace,repo, cb) {
-  scrap("https://registry.hub.docker.com/u/"+namespace+"/"+repo,function(e,$) {
+  var prefix = namespace==='_'?'':'u/';
+  scrap("https://registry.hub.docker.com/"+prefix+namespace+"/"+repo,function(e,$) {
     if(e) return cb(e)
     var result = {}
     result.stars = $('.stars').text().trim()


### PR DESCRIPTION
Added support for official repos:

example [redis](https://registry.hub.docker.com/_/redis/)

Can be accessed with: http://localhost:80/image/_/redis
