### PR TITLE
Fix handling of less than sign (<) in Docker Registry JSON

### DIFF
--- a/scrapper/index.js
+++ b/scrapper/index.js
@@ -3,21 +3,21 @@ var scrap = require('scrap')
 var m = module.exports = function (namespace, repo, cb) {
   if (namespace === '_') namespace = 'library' // allow us to use api
   var metaurl = 'https://registry.hub.docker.com/v2/repositories/' + namespace + '/' + repo
-  scrap(metaurl, function (e, $) {
+  scrap(metaurl, function (e, $, code, html) {
     if (e) return cb(e)
     var data = {pull_count: '?', is_automated: false, star_count: '?'}
     try {
-      data = JSON.parse($.html())
+      data = JSON.parse(html)
     } catch (e) {}
     var result = {}
     result.downloads = data.pull_count
     result.trusted = data.is_automated
     result.stars = data.star_count
     var starUrl = 'https://registry.hub.docker.com/v2/repositories/' + namespace + '/' + repo + '/comments'
-    scrap(starUrl, function (e, $) {
+    scrap(starUrl, function (e, $, code, html) {
       var data = { count: '?' }
       try {
-        data = JSON.parse($.html())
+        data = JSON.parse(html)
       } catch (e) {}
       result.comments = data.count
       return cb(null, result)


### PR DESCRIPTION
In case the Docker registry returns text with less than sign (`<`) in JSON the `$.html()` from `scrap` modul fails with `SyntaxError: Unexpected token <` error.

This can occur for example if you have something like following in your `README.md` which is then returned in `full_description` JSON field.
`docker run -d --name my_jenkins -v /C/Users/<your-profile>/Documents`

In this case, the rendered image contains `?` instead.
![error](https://cloud.githubusercontent.com/assets/3158339/21852285/c36d888c-d812-11e6-89bb-3cee4ddb4dad.png)

**Example image**
* [Doker hub](https://hub.docker.com/r/shimmi/jenkins)
* [Badly rendered dockeri.co image](http://dockeri.co/image/shimmi/jenkins)
* [Docker registry JSON](https://registry.hub.docker.com/v2/repositories/shimmi/jenkins/)